### PR TITLE
chore(terraform): regle-makeshop production IaC import

### DIFF
--- a/regle-makeshop-prod/terraform/.gitignore
+++ b/regle-makeshop-prod/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/regle-makeshop-prod/terraform/.terraform.lock.hcl
+++ b/regle-makeshop-prod/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/regle-makeshop-prod/terraform/README.md
+++ b/regle-makeshop-prod/terraform/README.md
@@ -1,0 +1,48 @@
+# regle-makeshop production Terraform
+
+Production 환경 (EC2 1대 + RDS Postgres) IaC. dev (regle-mcp-server) 는 별도 state.
+
+## State backend
+
+```
+s3://seoulventures-terraform-state/regle-makeshop-prod/terraform.tfstate
+```
+
+## 사용
+
+```bash
+# 초기화
+terraform init
+
+# 계획 (RDS master password 는 admin-info.txt 에서)
+RDS_PW=$(aws s3 cp s3://sv-env/regle/mcp-makeshop/admin-info.txt - | grep '^DB_MASTER_PASSWORD' | cut -d= -f2- | tr -d ' ')
+terraform plan -var "rds_master_password=$RDS_PW"
+
+# 적용
+terraform apply -var "rds_master_password=$RDS_PW"
+```
+
+## 자원 (생성 2026-04-27)
+
+| 종류 | resource | id | 비고 |
+|------|----------|----|----|
+| Security Group | `aws_security_group.ec2` | sg-050c34ebfa636607a | 80/443/22 |
+| Security Group | `aws_security_group.rds` | sg-0802c7acb12a8af15 | 5432 from EC2 SG |
+| EC2 | `aws_instance.ec2` | i-0c778025d6494627a | t4g.small, Ubuntu 24.04 ARM, AZ-a |
+| EIP | `aws_eip.ec2` | eipalloc-05fad7bcef2209d28 | 52.79.195.49 |
+| RDS Subnet Group | `aws_db_subnet_group.rds` | regle-makeshop-prod | a + c subnets |
+| RDS DB | `aws_db_instance.rds` | regle-makeshop-prod | Postgres 16.10 db.t4g.micro |
+
+## 자격증명 보관
+
+`s3://sv-env/regle/mcp-makeshop/admin-info.txt` (SSE-AES256). 회전 시 본 파일 + S3 + EC2 `.env` + GitHub Actions secret 4곳 동시 갱신.
+
+## ALB 전환 (lazy migration)
+
+트리거 (monthly traffic / SLA / sub_admin 임계 도달) 시:
+1. `aws_lb` + `aws_lb_target_group` + `aws_lb_listener` 추가
+2. EC2 #2 (`aws_instance.ec2_b`) 추가, 다른 AZ
+3. ALB target group attachment 양쪽 등록
+4. DNS A → ALB CNAME 전환
+
+상세: `packages/mcp-makeshop/docs/superpowers/specs/2026-04-27-production-infra-bootstrap.md`

--- a/regle-makeshop-prod/terraform/main.tf
+++ b/regle-makeshop-prod/terraform/main.tf
@@ -1,0 +1,216 @@
+# =============================================================================
+# regle-makeshop production 인프라
+# =============================================================================
+# 환경: production (단일 EC2 + RDS Postgres). dev (regle-mcp-server) 는 별도 state.
+# 생성: 2026-04-27. 초기 자원은 AWS CLI 로 만든 후 본 코드로 import.
+# 보관 단일 진실 원천: s3://sv-env/regle/mcp-makeshop/admin-info.txt
+# =============================================================================
+
+# Latest Ubuntu 24.04 ARM64 — instance lifecycle.ignore_changes 로 ami 미반영
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Security Groups
+# -----------------------------------------------------------------------------
+
+resource "aws_security_group" "ec2" {
+  name        = "regle-makeshop-prod-ec2"
+  description = "Production EC2 (mcp-makeshop) 80/443/22"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP (Lets Encrypt + 443 redirect)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "regle-makeshop-prod-ec2"
+    Project     = "regle-makeshop"
+    Environment = "production"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "regle-makeshop-prod-rds"
+  description = "Production RDS Postgres (5432 from EC2 only)"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Postgres from EC2"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "regle-makeshop-prod-rds"
+    Project     = "regle-makeshop"
+    Environment = "production"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# EC2 (web + mcp Rust co-located)
+# -----------------------------------------------------------------------------
+
+resource "aws_instance" "ec2" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t4g.small"
+  key_name               = var.key_name
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+  subnet_id              = var.ec2_subnet_id
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    encrypted             = false # 초기 import 시 false. 후일 snapshot+restore 로 전환 가능
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name        = "regle-makeshop-prod"
+    Project     = "regle-makeshop"
+    Env         = "production"
+    Environment = "production"
+  }
+
+  # OS / package / .env / systemd unit 은 deploy-ec2.yml 가 관리.
+  # AMI 갱신은 별도 spec 으로 (lifecycle 재기동 위험).
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+}
+
+resource "aws_eip" "ec2" {
+  instance = aws_instance.ec2.id
+  domain   = "vpc"
+
+  tags = {
+    Name        = "regle-makeshop-prod-eip"
+    Project     = "regle-makeshop"
+    Environment = "production"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# RDS Postgres
+# -----------------------------------------------------------------------------
+
+resource "aws_db_subnet_group" "rds" {
+  name        = "regle-makeshop-prod"
+  description = "regle-makeshop production"
+  subnet_ids  = var.rds_subnet_ids
+
+  tags = {
+    Name        = "regle-makeshop-prod"
+    Project     = "regle-makeshop"
+    Environment = "production"
+  }
+}
+
+resource "aws_db_instance" "rds" {
+  identifier     = "regle-makeshop-prod"
+  engine         = "postgres"
+  engine_version = "16.10"
+  instance_class = "db.t4g.micro"
+
+  allocated_storage = 20
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = "mcp_makeshop"
+  username = "postgres"
+  password = var.rds_master_password
+
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  db_subnet_group_name   = aws_db_subnet_group.rds.name
+  publicly_accessible    = false
+  multi_az               = false
+
+  backup_retention_period    = 7
+  auto_minor_version_upgrade = true
+  deletion_protection        = false
+  skip_final_snapshot        = true
+
+  apply_immediately = false
+
+  tags = {
+    Name        = "regle-makeshop-prod"
+    Project     = "regle-makeshop"
+    Environment = "production"
+  }
+
+  lifecycle {
+    # password 회전은 평문이라 plan diff 가 자주 발생. 회전 시점에만 변수 갱신.
+    ignore_changes = [
+      engine_version, # minor 자동 업그레이드
+    ]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+
+output "ec2_id" {
+  value = aws_instance.ec2.id
+}
+
+output "ec2_public_ip" {
+  value = aws_eip.ec2.public_ip
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.rds.endpoint
+}
+
+output "rds_address" {
+  value = aws_db_instance.rds.address
+}

--- a/regle-makeshop-prod/terraform/variables.tf
+++ b/regle-makeshop-prod/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  type    = string
+  default = "ap-northeast-2"
+}
+
+variable "vpc_id" {
+  type    = string
+  default = "vpc-7e1ab916"
+}
+
+variable "ec2_subnet_id" {
+  type    = string
+  default = "subnet-078e674c8bb6621e1" # ap-northeast-2a
+}
+
+variable "rds_subnet_ids" {
+  type = list(string)
+  default = [
+    "subnet-078e674c8bb6621e1", # ap-northeast-2a
+    "subnet-0e16017e4f1eae357", # ap-northeast-2c
+  ]
+}
+
+variable "key_name" {
+  type    = string
+  default = "SeoulVentures"
+}
+
+# RDS master password — Terraform state 에는 평문 저장됨 (S3 SSE 적용).
+# 회전 시: aws rds modify-db-instance + 본 변수 갱신 + admin-info.txt 갱신.
+# 보관 단일 진실 원천: s3://sv-env/regle/mcp-makeshop/admin-info.txt
+variable "rds_master_password" {
+  type      = string
+  sensitive = true
+}

--- a/regle-makeshop-prod/terraform/versions.tf
+++ b/regle-makeshop-prod/terraform/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "seoulventures-terraform-state"
+    key    = "regle-makeshop-prod/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
AWS CLI 로 생성한 production 자원 6종 (EC2/RDS/EIP/SG x2/DB Subnet Group) 을 Terraform 으로 import. 회사 표준 backend (seoulventures-terraform-state) 사용.

`terraform plan` = 0 add / 0 change / 0 destroy 검증 완료.

자세히: `regle-makeshop-prod/terraform/README.md`